### PR TITLE
SubsetCIDRs

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,6 @@ New `RemoveCIDRs` functions added (in June 2022) to remove/exclude CIDR blocks o
 New `SubsetCIDRs` functions added (in September 2022) to select specific CIDR blocks or IP ranges to keep.
 A bit like the oposite of RemoveCIDRs, `SubsetCIDRs` selects what to keep instead of what to remove.
 
-## The future
+## Upcoming
 
-For now, all necessary features have been added to support Netnod's internal development needs.
+New `DiffCIDRs` functions are planned to compare two lists of CIDR blocks or IP ranges.

--- a/README.md
+++ b/README.md
@@ -8,9 +8,10 @@ This is a fork from [EvilSuperstars/go-cidrman](https://github.com/EvilSuperstar
 
 ## Background
 
-*Note:* This project uses [Go Modules](https://blog.golang.org/using-go-modules) making it safe to work with it outside of
-your existing [GOPATH](http://golang.org/doc/code.html#GOPATH). The instructions that follow assume a directory in your
-home directory outside of the standard GOPATH (i.e `$HOME/git/GitHub/Netnod/go-cidrman/`).
+*Note:* This project uses [Go Modules](https://blog.golang.org/using-go-modules) making it
+safe to work with it outside of your existing [GOPATH](http://golang.org/doc/code.html#GOPATH).
+The instructions that follow assume a directory in your home directory
+outside of the standard GOPATH (i.e `$HOME/git/GitHub/Netnod/go-cidrman/`).
 
 # Build instructions
 
@@ -51,7 +52,8 @@ $ make clean
 ## Findings about the original project
 
 A lot of work was done in the `ipv6-experimental` branch in February and December 2017.
-In June 2019, some of the *metafiles* in the `master` branch were created or updated, without changes to the code itself.
+In June 2019, some of the *metafiles* in the `master` branch were created or updated,
+without changes to the code itself.
 
 ## Where are we now?
 
@@ -64,13 +66,11 @@ In April 2022, a `merge-experimental` branch was temporarily used to merge the o
 together with the IPv6 support developed in this fork.
 With IPv6 support now in `main`, the `ipv6-experimental` branch was removed as it's no longer relevant in this fork.
 
-New `RemoveCIDRs` functions were added (in June 2022) to remove/exclude CIDR blocks or IP ranges.
+New `RemoveCIDRs` functions added (in June 2022) to remove/exclude CIDR blocks or IP ranges.
 
-## Next to come
-
-New `SubsetCIDRs` functions in progress to select specific CIDR blocks or IP ranges to keep.
-A bit lite the oposite of RemoveCIDRs, this selects what to keep instead of what to remove.
+New `SubsetCIDRs` functions added (in September 2022) to select specific CIDR blocks or IP ranges to keep.
+A bit like the oposite of RemoveCIDRs, `SubsetCIDRs` selects what to keep instead of what to remove.
 
 ## The future
 
-For the time being, all needed features have been added to support Netnod's internal development needs.
+For now, all necessary features have been added to support Netnod's internal development needs.

--- a/README.md
+++ b/README.md
@@ -66,6 +66,11 @@ With IPv6 support now in `main`, the `ipv6-experimental` branch was removed as i
 
 New `RemoveCIDRs` functions were added (in June 2022) to remove/exclude CIDR blocks or IP ranges.
 
-## Upcoming
+## Next to come
 
-New `SubsetCIDRs` functions are planned to select specific CIDR blocks or IP ranges to keep.
+New `SubsetCIDRs` functions in progress to select specific CIDR blocks or IP ranges to keep.
+A bit lite the oposite of RemoveCIDRs, this selects what to keep instead of what to remove.
+
+## The future
+
+For the time being, all needed features have been added to support Netnod's internal development needs.

--- a/ipv4.go
+++ b/ipv4.go
@@ -250,9 +250,9 @@ func subset4(blocks, subsets cidrBlock4s) ([]*net.IPNet, error) {
 	i := 0
 	j := 0
 	for i < len(blocks) {
-		if j >= len(subsets) || subsets[j].last < blocks[i].first {
-			// No more subset blocks to compare with, or
-			// network-block entirely before subset-block, remove block and continue to next
+		if j >= len(subsets) || blocks[i].last < subsets[j].first {
+			// No more subset blocks to compare with (then no more network blocks to keep), or
+			// network-block entirely before subset-block, remove block and continue with next
 			//
 			// Clear network-block and continue to next
 			blocks[i] = nil
@@ -267,6 +267,7 @@ func subset4(blocks, subsets cidrBlock4s) ([]*net.IPNet, error) {
 		} else if blocks[i].first >= subsets[j].first {
 			// Network-block starts inside subset-block, adjust end of network-block
 			blocks[i].last = subsets[j].last
+			i++
 			j++
 		} else if blocks[i].last <= subsets[j].last {
 			// Network-block ends inside subset-block, adjust start of network-block

--- a/ipv4.go
+++ b/ipv4.go
@@ -6,6 +6,7 @@ import (
 	"math"
 	"net"
 	"sort"
+	"errors"
 )
 
 const widthUInt32 = 32
@@ -239,4 +240,10 @@ func remove4(blocks, removes cidrBlock4s) ([]*net.IPNet, error) {
 	}
 
 	return merged, nil
+}
+
+// subset4 accepts two lists of IPv4 networks and return a new list of IPNets that exsists/overlaps in both lists.
+// The subset4() will return the smallest possible list of IPNets.
+func subset4(blocks, subsets cidrBlock4s) ([]*net.IPNet, error) {
+	return nil, errors.New("subset4() not implemented yet")
 }

--- a/ipv4.go
+++ b/ipv4.go
@@ -6,7 +6,6 @@ import (
 	"math"
 	"net"
 	"sort"
-	"errors"
 )
 
 const widthUInt32 = 32
@@ -245,5 +244,65 @@ func remove4(blocks, removes cidrBlock4s) ([]*net.IPNet, error) {
 // subset4 accepts two lists of IPv4 networks and return a new list of IPNets that exsists/overlaps in both lists.
 // The subset4() will return the smallest possible list of IPNets.
 func subset4(blocks, subsets cidrBlock4s) ([]*net.IPNet, error) {
-	return nil, errors.New("subset4() not implemented yet")
+	sort.Sort(blocks)
+	sort.Sort(subsets)
+
+	i := 0
+	j := 0
+	for i < len(blocks) {
+		if j >= len(subsets) || subsets[j].last < blocks[i].first {
+			// No more subset blocks to compare with, or
+			// network-block entirely before subset-block, remove block and continue to next
+			//
+			// Clear network-block and continue to next
+			blocks[i] = nil
+			i++
+		} else if subsets[j].last < blocks[i].first {
+			// Subset-block entirely before network-block, use next subset-block
+			j++
+		} else if blocks[i].first >= subsets[j].first && blocks[i].last <= subsets[j].last {
+			// Network-block inside subset-block, keep that network-block
+			i++
+		// From here on we have some sort of overlap
+		} else if blocks[i].first >= subsets[j].first {
+			// Network-block starts inside subset-block, adjust end of network-block
+			blocks[i].last = subsets[j].last
+			j++
+		} else if blocks[i].last <= subsets[j].last {
+			// Network-block ends inside subset-block, adjust start of network-block
+			blocks[i].first = subsets[j].first
+			i++
+		} else {
+			// Subset-block inside network-block, adjust both start and end of network-block
+			blocks[i].first = subsets[j].first
+			// Check if next subset-block exists and starts with network-block
+			if j < len(subsets) - 1 && subsets[j+1].first < blocks[i].last {
+				// Make room for new network block
+				blocks = append(blocks, nil)
+				copy(blocks[i+1:], blocks[i:])
+				blocks[i] = new(cidrBlock4)
+				// update first half of the network-block (new)
+				blocks[i].first = subsets[j].first
+				// Update second half of the network-block (old)
+				blocks[i+1].first = subsets[j+1].first
+			}
+			// Finaly handle (first) network-block's last address
+			blocks[i].last = subsets[j].last
+			i++
+			j++
+		}
+	}
+
+	var overlaps []*net.IPNet
+	for _, block := range blocks {
+		if block == nil {
+			continue
+		}
+
+		if err := splitRange4(0, 0, block.first, block.last, &overlaps); err != nil {
+			return nil, err
+		}
+	}
+
+	return overlaps, nil
 }

--- a/ipv6.go
+++ b/ipv6.go
@@ -5,6 +5,7 @@ import (
 	"math/big"
 	"net"
 	"sort"
+	"errors"
 )
 
 const widthUInt128 = 128
@@ -253,4 +254,10 @@ func remove6(blocks, removes cidrBlock6s) ([]*net.IPNet, error) {
 	}
 
 	return merged, nil
+}
+
+// subset6 accepts two lists of IPv6 networks and return a new list of IPNets that exsists/overlaps in both lists.
+// The subset6() will return the smallest possible list of IPNets.
+func subset6(blocks, subsets cidrBlock6s) ([]*net.IPNet, error) {
+	return nil, errors.New("subset6() not implemented yet")
 }

--- a/ipv6.go
+++ b/ipv6.go
@@ -5,7 +5,6 @@ import (
 	"math/big"
 	"net"
 	"sort"
-	"errors"
 )
 
 const widthUInt128 = 128
@@ -259,5 +258,66 @@ func remove6(blocks, removes cidrBlock6s) ([]*net.IPNet, error) {
 // subset6 accepts two lists of IPv6 networks and return a new list of IPNets that exsists/overlaps in both lists.
 // The subset6() will return the smallest possible list of IPNets.
 func subset6(blocks, subsets cidrBlock6s) ([]*net.IPNet, error) {
-	return nil, errors.New("subset6() not implemented yet")
+	sort.Sort(blocks)
+	sort.Sort(subsets)
+
+	i := 0
+	j := 0
+	for i < len(blocks) {
+		if j >= len(subsets) || blocks[i].last.Cmp(subsets[j].first) < 0 {
+			// No more subset blocks to compare with (then no more network blocks to keep), or
+			// network-block entirely before subset-block, remove block and continue with next
+			//
+			// Clear network-block and continue to next
+			blocks[i] = nil
+			i++
+		} else if subsets[j].last.Cmp(blocks[i].first) < 0 {
+			// Subset-block entirely before network-block, use next subset-block
+			j++
+		} else if blocks[i].first.Cmp(subsets[j].first) >= 0 && blocks[i].last.Cmp(subsets[j].last) <= 0 {
+			// Network-block inside subset-block, keep that network-block
+			i++
+		// From here on we have some sort of overlap
+		} else if blocks[i].first.Cmp(subsets[j].first) >= 0 {
+			// Network-block starts inside subset-block, adjust end of network-block
+			blocks[i].last = subsets[j].last
+			i++
+			j++
+		} else if blocks[i].last.Cmp(subsets[j].last) <= 0 {
+			// Network-block ends inside subset-block, adjust start of network-block
+			blocks[i].first = subsets[j].first
+			i++
+		} else {
+			// Subset-block inside network-block, adjust both start and end of network-block
+			blocks[i].first = subsets[j].first
+			// Check if next subset-block exists and starts with network-block
+			if j < len(subsets) - 1 && subsets[j+1].first.Cmp(blocks[i].last) < 0 {
+				// Make room for new network block
+				blocks = append(blocks, nil)
+				copy(blocks[i+1:], blocks[i:])
+				blocks[i] = new(cidrBlock6)
+				// update first half of the network-block (new)
+				blocks[i].first = subsets[j].first
+				// Update second half of the network-block (old)
+				blocks[i+1].first = subsets[j+1].first
+			}
+			// Finaly handle (first) network-block's last address
+			blocks[i].last = subsets[j].last
+			i++
+			j++
+		}
+	}
+
+	var overlaps []*net.IPNet
+	for _, block := range blocks {
+		if block == nil {
+			continue
+		}
+
+		if err := splitRange6(big.NewInt(0), 0, block.first, block.last, &overlaps); err != nil {
+			return nil, err
+		}
+	}
+
+	return overlaps, nil
 }

--- a/merge.go
+++ b/merge.go
@@ -14,7 +14,6 @@ func (nets ipNets) toCIDRs() []string {
 	for _, net := range nets {
 		cidrs = append(cidrs, net.String())
 	}
-
 	return cidrs
 }
 
@@ -42,14 +41,21 @@ func MergeIPNets(nets []*net.IPNet) ([]*net.IPNet, error) {
 		}
 	}
 
-	merged4, err := merge4(block4s)
-	if err != nil {
-		return nil, err
+	var merged4 []*net.IPNet
+	var err error
+	if len(block4s) > 0 {
+		merged4, err = merge4(block4s)
+		if err != nil {
+			return nil, err
+		}
 	}
 
-	merged6, err := merge6(block6s)
-	if err != nil {
-		return nil, err
+	var merged6 []*net.IPNet
+	if len(block6s) > 0 {
+		merged6, err = merge6(block6s)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	merged := append(merged4, merged6...)

--- a/merge.go
+++ b/merge.go
@@ -29,7 +29,7 @@ func MergeIPNets(nets []*net.IPNet) ([]*net.IPNet, error) {
 	}
 
 	// Split into IPv4 and IPv6 lists.
-	// Merge the list separately and then combine.
+	// Handle the lists separately and then combine.
 	var block4s cidrBlock4s
 	var block6s cidrBlock6s
 	for _, net := range nets {

--- a/remove.go
+++ b/remove.go
@@ -33,7 +33,7 @@ func RemoveIPNets(nets, rmnets []*net.IPNet) ([]*net.IPNet, error) {
 	}
 
 	// Split into IPv4 and IPv6 lists.
-	// Merge the list separately and then combine.
+	// Handle the lists separately and then combine.
 	var block4s cidrBlock4s
 	var block6s cidrBlock6s
 	for _, net := range nets {

--- a/remove.go
+++ b/remove.go
@@ -57,14 +57,20 @@ func RemoveIPNets(nets, rmnets []*net.IPNet) ([]*net.IPNet, error) {
 		}
 	}
 
-	new4s, err := remove4(block4s, remove4s)
-	if err != nil {
-		return nil, err
+	var new4s []*net.IPNet
+	if len(block4s) > 0 {
+		new4s, err = remove4(block4s, remove4s)
+		if err != nil {
+			return nil, err
+		}
 	}
 
-	new6s, err := remove6(block6s, remove6s)
-	if err != nil {
-		return nil, err
+	var new6s []*net.IPNet
+	if len(block6s) > 0 {
+		new6s, err = remove6(block6s, remove6s)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	merged := append(new4s, new6s...)

--- a/remove_test.go
+++ b/remove_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 )
 
-func TestRremoveCIDRs(t *testing.T) {
+func TestRemoveCIDRs(t *testing.T) {
 	type TestCase struct {
 		Input  []string
 		Remove []string

--- a/subset.go
+++ b/subset.go
@@ -1,0 +1,116 @@
+package cidrman
+
+import (
+	"net"
+)
+
+// SubsetIPNets accepts two lists of mixed IP networks and return a new list of IPNets that exsists/overlaps in both lists.
+// The SubsetIPNets() will return the smallest possible list of IPNets.
+// Example:
+//     internalNets, err := SubsetIPNets(mixedListOfNets, rfc1918nets)
+func SubsetIPNets(nets, subsetnets []*net.IPNet) ([]*net.IPNet, error) {
+	if nets == nil {
+		return nil, nil
+	}
+	if len(nets) == 0 {
+		return make([]*net.IPNet, 0), nil
+	}
+	if subsetnets == nil {
+		return nets, nil
+	}
+	if len(subsetnets) == 0 {
+		return nets, nil
+	}
+
+	// Merge nets and subsetnets individually to have the miminal set of largets networks
+	nets, err := MergeIPNets(nets)
+	if err != nil {
+		return nil, err
+	}
+	subsetnets, err = MergeIPNets(subsetnets)
+	if err != nil {
+		return nil, err
+	}
+
+	// Split into IPv4 and IPv6 lists.
+	// Handle the list separately and then combine.
+	var block4s cidrBlock4s
+	var block6s cidrBlock6s
+	for _, net := range nets {
+		ip4 := net.IP.To4()
+		if ip4 != nil {
+			block4s = append(block4s, newBlock4(ip4, net.Mask))
+		} else {
+			ip6 := net.IP.To16()
+			block6s = append(block6s, newBlock6(ip6, net.Mask))
+		}
+	}
+	var subset4s cidrBlock4s
+	var subset6s cidrBlock6s
+	for _, net := range subsetnets {
+		ip4 := net.IP.To4()
+		if ip4 != nil {
+			subset4s = append(subset4s, newBlock4(ip4, net.Mask))
+		} else {
+			ip6 := net.IP.To16()
+			subset6s = append(subset6s, newBlock6(ip6, net.Mask))
+		}
+	}
+
+	new4s, err := subset4(block4s, subset4s)
+	if err != nil {
+		return nil, err
+	}
+
+	new6s, err := subset6(block6s, subset6s)
+	if err != nil {
+		return nil, err
+	}
+
+	merged := append(new4s, new6s...)
+	return merged, nil
+}
+
+// SubsetCIDRs accepts two lists of mixed CIDR blocks and return a new list of CIDRs that exsists/overlaps in both lists.
+func SubsetCIDRs(cidrs, subsets []string) ([]string, error) {
+	if cidrs == nil {
+		return nil, nil
+	}
+	if len(cidrs) == 0 {
+		return make([]string, 0), nil
+	}
+	if subsets == nil {
+		return cidrs, nil
+	}
+	if len(subsets) == 0 {
+		return cidrs, nil
+	}
+
+	var networks []*net.IPNet
+	for _, cidr := range cidrs {
+		_, network, err := net.ParseCIDR(cidr)
+		if err != nil {
+			return nil, err
+		}
+		networks = append(networks, network)
+	}
+	var subsetnets []*net.IPNet
+	for _, cidr := range subsets {
+		_, network, err := net.ParseCIDR(cidr)
+		if err != nil {
+			return nil, err
+		}
+		subsetnets = append(subsetnets, network)
+	}
+
+	newNets, err := SubsetIPNets(networks, subsetnets)
+	if err != nil {
+		return nil, err
+	}
+	// Handle the situation where no cidrs overlapped
+	if len(newNets) == 0 {
+		return make([]string, 0), nil
+	}
+
+	return ipNets(newNets).toCIDRs(), nil
+}

--- a/subset.go
+++ b/subset.go
@@ -16,10 +16,16 @@ func SubsetIPNets(nets, subsetnets []*net.IPNet) ([]*net.IPNet, error) {
 		return make([]*net.IPNet, 0), nil
 	}
 	if subsetnets == nil {
-		return nets, nil
+		// With empty subset, return empty result
+		return make([]*net.IPNet, 0), nil
+		// Alternative to return nets unchanged
+		//return nets, nil
 	}
 	if len(subsetnets) == 0 {
-		return nets, nil
+		// With empty subset, return empty result
+		return make([]*net.IPNet, 0), nil
+		// Alternative to return nets unchanged
+		//return nets, nil
 	}
 
 	// Merge nets and subsetnets individually to have the miminal set of largets networks
@@ -86,10 +92,16 @@ func SubsetCIDRs(cidrs, subsets []string) ([]string, error) {
 		return make([]string, 0), nil
 	}
 	if subsets == nil {
-		return cidrs, nil
+		// With empty subset, return empty result
+		return make([]string, 0), nil
+		// Alternative to return cidrs unchanged
+		//return cidrs, nil
 	}
 	if len(subsets) == 0 {
-		return cidrs, nil
+		// With empty subset, return empty result
+		return make([]string, 0), nil
+		// Alternative to return cidrs unchanged
+		//return cidrs, nil
 	}
 
 	var networks []*net.IPNet

--- a/subset.go
+++ b/subset.go
@@ -57,14 +57,20 @@ func SubsetIPNets(nets, subsetnets []*net.IPNet) ([]*net.IPNet, error) {
 		}
 	}
 
-	new4s, err := subset4(block4s, subset4s)
-	if err != nil {
-		return nil, err
+	var new4s []*net.IPNet
+	if len(block4s) > 0 {
+		new4s, err = subset4(block4s, subset4s)
+		if err != nil {
+			return nil, err
+		}
 	}
 
-	new6s, err := subset6(block6s, subset6s)
-	if err != nil {
-		return nil, err
+	var new6s []*net.IPNet
+	if len(block6s) > 0 {
+		new6s, err = subset6(block6s, subset6s)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	merged := append(new4s, new6s...)

--- a/subset_test.go
+++ b/subset_test.go
@@ -1,0 +1,478 @@
+// go test -v -run="TestSubsetCIDRs"
+
+package cidrman
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestSubsetCIDRs(t *testing.T) {
+	type TestCase struct {
+		Input  []string
+		Subset []string
+		Output []string
+		Error  bool
+	}
+
+	testCases := []TestCase{
+		{
+			Input:  nil,
+			Subset: nil,
+			Output: nil,
+			Error:  false,
+		},
+		{
+			Input:  []string{},
+			Subset: nil,
+			Output: []string{},
+			Error:  false,
+		},
+		{
+			Input:  nil,
+			Subset: []string{},
+			Output: nil,
+			Error:  false,
+		},
+		{
+			Input:  []string{},
+			Subset: []string{},
+			Output: []string{},
+			Error:  false,
+		},
+		{
+			Input:  []string{
+				"10.0.0.0/8",
+			},
+			Subset: []string{},
+			// With nothing to keep, we get back an empty list
+			Output: []string{},
+			Error:  false,
+		},
+		{
+			Input:  []string{
+				"10.0.0.0/8",
+			},
+			Subset: nil,
+			Output: []string{},
+			Error:  false,
+		},
+		{
+			Input:  nil,
+			Subset: []string{
+				"10.0.0.0/8",
+			},
+			Output: nil,
+			Error:  false,
+		},
+		{
+			Input:  []string{
+				"10.0.0.0/8",
+			},
+			Subset: []string{
+				"10.0.0.0/8",
+			},
+			Output: []string{
+				"10.0.0.0/8",
+			},
+			Error:  false,
+		},
+		{
+			Input:  []string{
+				"10.0.0.0/8",
+				"0.0.0.0/0",
+			},
+			Subset: []string{
+				"127.0.0.0/8",
+			},
+			Output: []string{
+				"127.0.0.0/8",
+			},
+			Error:  false,
+		},
+		{
+			Input:  []string{
+				"10.0.0.0/8",
+				"10.0.0.0/8",
+			},
+			Subset: []string{
+				"10.0.0.0/8",
+			},
+			Output: []string{
+				"10.0.0.0/8",
+			},
+			Error:  false,
+		},
+		{
+			Input:  []string{
+				"192.0.128.0/24",
+				"192.0.129.0/24",
+			},
+			Subset: []string{
+				"192.0.0.0/16",
+			},
+			// SubsetIPNets will first do MergeIPNets() before processing the subset list
+			Output: []string{
+				"192.0.128.0/23",
+			},
+			Error:  false,
+		},
+		{
+			Input:  []string{
+				"192.0.128.0/24",
+				"192.0.129.0/24",
+			},
+			Subset: []string{
+				"192.0.128.128/25",
+				"192.0.129.0/25",
+			},
+			Output: []string{
+				"192.0.128.128/25",
+				"192.0.129.0/25",
+			},
+			Error:  false,
+		},
+		{
+			Input:  []string{
+				"192.0.128.0/24",
+				"192.0.139.0/24",
+			},
+			Subset: []string{
+				"192.0.128.0/23",
+			},
+			Output: []string{
+				"192.0.128.0/24",
+			},
+			Error:  false,
+		},
+		{
+			Input:  []string{
+				"172.16.10.0/24",
+				"172.16.11.0/24",
+				"172.16.12.0/24",
+				"172.16.13.0/24",
+				"172.16.14.0/24",
+			},
+			Subset: []string{
+				"172.16.8.0/22",
+			},
+			Output: []string{
+				"172.16.10.0/23",
+			},
+			Error:  false,
+		},
+		{
+			Input:  []string{
+				"172.16.10.0/24",
+				"172.16.11.0/24",
+				"172.16.12.0/24",
+				"172.16.13.0/24",
+				"172.16.14.0/24",
+			},
+			Subset: []string{
+				"172.16.12.0/22",
+			},
+			Output: []string{
+				"172.16.12.0/23",
+				"172.16.14.0/24",
+			},
+			Error:  false,
+		},
+		{
+			Input:  []string{
+				"172.16.8.0/20",
+			},
+			Subset: []string{
+				"172.16.12.0/24",
+				"172.16.14.0/24",
+			},
+			Output: []string{
+				"172.16.12.0/24",
+				"172.16.14.0/24",
+			},
+			Error:  false,
+		},
+		{
+			Input:  []string{
+				"172.16.10.0/24",
+				"172.16.11.0/24",
+				"172.16.12.0/24",
+				"172.16.13.0/24",
+				"172.16.14.0/24",
+			},
+			Subset: []string{
+				"172.16.8.0/21",
+			},
+			Output: []string{
+				"172.16.10.0/23",
+				"172.16.12.0/23",
+				"172.16.14.0/24",
+			},
+			Error:  false,
+		},
+		{
+			Input:  []string{
+				"10.0.0.0/8",
+				"172.16.10.0/24",
+				"172.16.11.0/24",
+				"172.16.12.0/24",
+				"172.16.13.0/24",
+				"172.16.14.0/24",
+				"192.0.128.0/23",
+				"192.0.139.0/24",
+			},
+			Subset: []string{
+				"172.16.8.0/22",
+				"10.10.10.0/24",
+				"172.16.13.0/24",
+				"172.16.14.128/26",
+			},
+			Output: []string{
+				"10.10.10.0/24",
+				"172.16.10.0/23",
+				"172.16.13.0/24",
+				"172.16.14.128/26",
+			},
+			Error:  false,
+		},
+		// IPv6 tests
+		{
+			Input: []string{
+				"::/0",
+			},
+			Subset: []string{},
+			// With nothing to keep, we get back an empty list
+			Output: []string{},
+			Error: false,
+		},
+		{
+			Input:  []string{
+				"fd00::/8",
+			},
+			Subset: nil,
+			Output: []string{},
+			Error:  false,
+		},
+		{
+			Input:  nil,
+			Subset: []string{
+				"fd00::/8",
+			},
+			Output: nil,
+			Error:  false,
+		},
+		{
+			Input:  []string{
+				"fd00::/8",
+			},
+			Subset: []string{
+				"fd00::/8",
+			},
+			Output: []string{
+				"fd00::/8",
+			},
+			Error:  false,
+		},
+		{
+			Input:  []string{
+				"fd00::/8",
+				"::/0",
+			},
+			Subset: []string{
+				"2001:db8:0:2::/64",
+			},
+			Output: []string{
+				"2001:db8:0:2::/64",
+			},
+			Error:  false,
+		},
+		{
+			Input:  []string{
+				"2001:db8:0:2::/64",
+				"2001:db8:0:2::/64",
+			},
+			Subset: []string{
+				"2001:db8:0:2::/64",
+			},
+			Output: []string{
+				"2001:db8:0:2::/64",
+			},
+			Error:  false,
+		},
+		{
+			Input:  []string{
+				"2001:db8:0:2::/64",
+				"2001:db8:0:3::/64",
+			},
+			Subset: []string{
+				"2001:db8::/32",
+				"fd00::/8",
+			},
+			// SubsetIPNets will first do MergeIPNets() before processing the subset list
+			Output: []string{
+				"2001:db8:0:2::/63",
+			},
+			Error:  false,
+		},
+		{
+			Input:  []string{
+				"2001:db8:0:2::/64",
+				"2001:db8:0:3::/64",
+			},
+			Subset: []string{
+				"2001:db8:0:2:ffff::/72",
+				"2001:db8:0:3::/80",
+			},
+			Output: []string{
+				"2001:db8:0:2:ff00::/72",
+				"2001:db8:0:3::/80",
+			},
+			Error:  false,
+		},
+		{
+			Input:  []string{
+				"2001:db8:0:2::/64",
+				"2001:db8:1:3::/64",
+			},
+			Subset: []string{
+				"2001:db8::/48",
+			},
+			Output: []string{
+				"2001:db8:0:2::/64",
+			},
+			Error:  false,
+		},
+		{
+			Input:  []string{
+				"fd00:0:4711:a::/64",
+				"fd00:0:4711:b::/64",
+				"fd00:0:4711:c::/64",
+				"fd00:0:4711:d::/64",
+				"fd00:0:4711:e::/64",
+			},
+			Subset: []string{
+				"fd00:0:4711:8::/62",
+			},
+			Output: []string{
+				"fd00:0:4711:a::/63",
+			},
+			Error:  false,
+		},
+		{
+			Input:  []string{
+				"fd00:0:4711:a::/64",
+				"fd00:0:4711:b::/64",
+				"fd00:0:4711:c::/64",
+				"fd00:0:4711:d::/64",
+				"fd00:0:4711:e::/64",
+			},
+			Subset: []string{
+				"fd00:0:4711:c::/62",
+			},
+			Output: []string{
+				"fd00:0:4711:c::/63",
+				"fd00:0:4711:e::/64",
+			},
+			Error:  false,
+		},
+		{
+			Input:  []string{
+				"fd00:0:4711:8::/61",
+			},
+			Subset: []string{
+				"fd00:0:4711:c::/64",
+				"fd00:0:4711:e::/64",
+			},
+			Output: []string{
+				"fd00:0:4711:c::/64",
+				"fd00:0:4711:e::/64",
+			},
+			Error:  false,
+		},
+		{
+			Input:  []string{
+				"fd00:0:4711:a::/64",
+				"fd00:0:4711:b::/64",
+				"fd00:0:4711:c::/64",
+				"fd00:0:4711:d::/64",
+				"fd00:0:4711:e::/64",
+			},
+			Subset: []string{
+				"fd00:0:4711:8::/61",
+			},
+			Output: []string{
+				"fd00:0:4711:a::/63",
+				"fd00:0:4711:c::/63",
+				"fd00:0:4711:e::/64",
+			},
+			Error:  false,
+		},
+		// Mixed blocks
+		{
+			Input:  []string{
+				"fd00::/8",
+			},
+			Subset: []string{
+				"10.0.0.0/8",
+			},
+			Output: []string{},
+			Error:  false,
+		},
+		{
+			Input:  []string{
+				"fd00::/8",
+				"0.0.0.0/4",
+			},
+			Subset: []string{
+				"10.0.0.0/8",
+			},
+			Output: []string{
+				"10.0.0.0/8",
+			},
+			Error:  false,
+		},
+		{
+			Input:  []string{
+				"10.0.0.0/8",
+				"fc00::/7",
+			},
+			Subset: []string{
+				"fd00::/8",
+			},
+			Output: []string{
+				"fd00::/8",
+			},
+			Error:  false,
+		},
+		{
+			Input:  []string{
+				"10.0.0.0/8",
+				"2001:db8:0:2::/64",
+				"2001:db8:0:3::/64",
+				"192.0.128.0/24",
+				"192.0.129.0/24",
+			},
+			Subset: []string{
+				"192.0.128.0/24",
+				"2001:db8:0:3::/64",
+			},
+			Output: []string{
+				"192.0.128.0/24",
+				"2001:db8:0:3::/64",
+			},
+			Error:  false,
+		},
+	}
+
+	for _, testCase := range testCases {
+		output, err := SubsetCIDRs(testCase.Input, testCase.Subset)
+		if err != nil {
+			if !testCase.Error {
+				t.Errorf("SubsetCIDRs(%#v, %#v) failed: %s", testCase.Input, testCase.Subset, err.Error())
+			}
+		}
+		if !reflect.DeepEqual(testCase.Output, output) {
+			t.Errorf("SubsetCIDRs(%#v, %#v) expected: %#v, got: %#v", testCase.Input, testCase.Subset, testCase.Output, output)
+		}
+	}
+}


### PR DESCRIPTION
- Added new functions SubsetCIDRs() and SubsetIPNets() together with the corresponding IPv4 and IPv6 code.
- Minor updates to merge.go and remove.go, to have same internal behavior as subset.go
- README updated with relevant info.